### PR TITLE
[hotfix] fix enums for mobile delivery status

### DIFF
--- a/src/Enums.js
+++ b/src/Enums.js
@@ -118,7 +118,8 @@ exports.DeliveryType = {
 
 exports.DeliveryStatus = {
     SCHEDULED: 'scheduled',
-    IP: 'in_progress',
+    STARTED: 'started',
+    PICKED_UP: 'picked_up',
     COMPLETED: 'completed'
 };
 


### PR DESCRIPTION
delivery status seemed to have gotten reverted back during someone's merge conflict at some point, fixing it back