### PR TITLE
added emergency toggle to request-pickup-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,27 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-react-app": "^3.1.2",
     "create-react-class": "^15.6.3",
-    "firebase": "^4.9.1",
-    "google-maps-react": "^1.1.2",
+    "firebase": "^4.6.2",
+    "google-maps-react": "^1.1.11",
     "lodash.once": "^4.1.1",
     "lodash.pick": "^4.4.0",
     "merge-class-names": "^1.1.1",
     "moment": "^2.21.0",
     "moment-timezone": "^0.5.14",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0",
     "react-geocode": "0.0.7",
     "react-lifecycles-compat": "^3.0.2",
+    "react-native": "^0.57.3",
     "react-router-dom": "^4.2.2",
     "react-scripts": "^1.1.4",
+    "react-switch": "^3.0.4",
+    "react-toggle": "^4.0.2",
+    "react-toggle-button": "^2.2.0",
+    "react-toggle-switch": "^3.0.4",
     "roboto-fontface": "^0.8.0",
     "styled-components": "^3.0.2",
     "typeface-roboto": "0.0.54"
@@ -35,5 +42,18 @@
     "eslint-plugin-react": "^7.7.0",
     "google-map-react": "^0.32.0",
     "react-notification-badge": "^1.3.4"
-  }
+  },
+  "description": "This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jkbach/MealMatchup.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/jkbach/MealMatchup/issues"
+  },
+  "homepage": "https://github.com/jkbach/MealMatchup#readme"
 }

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -313,10 +313,11 @@ class RecurringPickupRequest extends Component {
             });
     }
 
-    componentWillUnmount() {
-        this.isEmergency = false;
+    handleToggle() {
+        this.setState({
+            isEmergency: !this.state.isEmergency,
+        })
     }
-
     render() {
         return (
             <div> 
@@ -342,10 +343,9 @@ class RecurringPickupRequest extends Component {
                                         onToggle={(value) => {
                                             this.setState({
                                                 value: !value,
-                                                isEmergency: !this.state.isEmergency,
                                                 
                                             });
-                                            {/*this.setState({isEmergency: !this.state.isEmergency});*/}
+                                            this.handleToggle
                                         }} 
                                     /> 
                                 </div>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -316,7 +316,7 @@ class RecurringPickupRequest extends Component {
     handleToggle() {
         this.setState({
             isEmergency: !this.state.isEmergency,
-        })
+        });
     }
     render() {
         return (
@@ -345,7 +345,7 @@ class RecurringPickupRequest extends Component {
                                                 value: !value,
                                                 
                                             });
-                                            this.handleToggle
+                                            this.handleToggle;
                                         }} 
                                     /> 
                                 </div>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -324,8 +324,8 @@ class RecurringPickupRequest extends Component {
                 <div className="form">
                     <form id={this.formId} onSubmit={this.createRequest}>
                         <div className="info">
-                            <label className= "toggle">
-                                <span>Regular</span>
+                            <div className= "toggle">
+                                <label><span>Regular</span></label>
                                 <div className = "button">
                                     <ToggleButton
                                         inactiveLabel={''}
@@ -349,8 +349,8 @@ class RecurringPickupRequest extends Component {
                                         }} 
                                     /> 
                                 </div>
-                                <span>Emergency</span>
-                            </label>
+                                <label> <span>Emergency</span></label>
+                            </div>
                             <p id="form-heading">Schedule Recurring Pickup</p>
                             {Object.keys(this.state.errors).map((error, i) => {
                                 return (

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -11,8 +11,8 @@ import './RequestPickup.css';
 import PickupSummary from './PickupSummary.js';
 import PickupRequestedConfirmation from './PickupRequestedConfirmation';
 import moment from 'moment-timezone';
-import Switch from "react-toggle-switch";
-import ToggleButton from 'react-toggle-button'
+import Switch from 'react-toggle-switch';
+import ToggleButton from 'react-toggle-button';
 
 class RecurringPickupRequest extends Component {
     constructor(props) {
@@ -30,7 +30,8 @@ class RecurringPickupRequest extends Component {
             primaryContact: {},
             raRequested: null,
             dgRequested: null,
-            submissionError: null
+            submissionError: null,
+            isEmergency: false
         };
 
         this.formId = 'recurringRequestForm';
@@ -323,8 +324,8 @@ class RecurringPickupRequest extends Component {
                                 <span>Regular</span>
                                 <div className = "button">
                                     <ToggleButton
-                                        inactiveLabel={""}
-                                        activeLabel={""}
+                                        inactiveLabel={''}
+                                        activeLabel={''}
                                         colors={{
                                             active: {
                                                 base: '#e60000',
@@ -334,16 +335,18 @@ class RecurringPickupRequest extends Component {
                                             }
                                         }}
                                         value={this.state.value}
+
                                         onToggle={(value) => {
                                             this.setState({
                                                 value: !value,
-
+                                                
                                             })
+                                            this.state.isEmergency = !this.state.isEmergency;
                                         }} 
                                     /> 
                                 </div>
                                 <span>Emergency</span>
-                            </label>
+                             </label>
                             <p id="form-heading">Schedule Recurring Pickup</p>
                             {Object.keys(this.state.errors).map((error, i) => {
                                 return (

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -317,41 +317,33 @@ class RecurringPickupRequest extends Component {
         return (
             <div> 
                 <div className="form">
-                    {/* <div className = "toggle"> 
-                        <input type="item" value="Emergency" />
-                        <input type="item" value="Regular" />
-                    </div>} */}
-                   { /*<label>*/}
-
-                    <div className= "toggle">
-                        <span>Regular</span>
-                        <div className="button">
-                        <ToggleButton className="button"
-                                inactiveLabel={""}
-                                activeLabel={""}
-                                colors={{
-                                    active: {
-                                        base: '#e60000',
-                                    },
-                                    inactive: {
-                                        base: 'rgb(0, 153, 51)',
-                                    }
-                                }}
-                                value={this.state.value}
-                                onToggle={(value) => {
-                                    this.setState({
-                                        value: !value,
-
-                                    })
-                                }} 
-                            /> 
-                            </div>
-                            <span> Emergency</span>
-
-                    </div>
-                    {/*</label>*/}
                     <form id={this.formId} onSubmit={this.createRequest}>
                         <div className="info">
+                            <label className= "toggle">
+                                <span>Regular</span>
+                                <div className = "button">
+                                    <ToggleButton
+                                        inactiveLabel={""}
+                                        activeLabel={""}
+                                        colors={{
+                                            active: {
+                                                base: '#e60000',
+                                            },
+                                            inactive: {
+                                                base: 'rgb(0, 153, 51)',
+                                            }
+                                        }}
+                                        value={this.state.value}
+                                        onToggle={(value) => {
+                                            this.setState({
+                                                value: !value,
+
+                                            })
+                                        }} 
+                                    /> 
+                                </div>
+                                <span>Emergency</span>
+                            </label>
                             <p id="form-heading">Schedule Recurring Pickup</p>
                             {Object.keys(this.state.errors).map((error, i) => {
                                 return (

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -345,7 +345,7 @@ class RecurringPickupRequest extends Component {
                                                 value: !value,
                                                 
                                             });
-                                            this.handleToggle;
+                                            this.handleToggle();
                                         }} 
                                     /> 
                                 </div>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -11,7 +11,6 @@ import './RequestPickup.css';
 import PickupSummary from './PickupSummary.js';
 import PickupRequestedConfirmation from './PickupRequestedConfirmation';
 import moment from 'moment-timezone';
-import Switch from 'react-toggle-switch';
 import ToggleButton from 'react-toggle-button';
 
 class RecurringPickupRequest extends Component {
@@ -341,7 +340,7 @@ class RecurringPickupRequest extends Component {
                                                 value: !value,
                                                 
                                             });
-                                            this.state.isEmergency = !this.state.isEmergency;
+                                            this.setState({isEmergency: !this.state.isEmergency});
                                         }} 
                                     /> 
                                 </div>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -313,6 +313,10 @@ class RecurringPickupRequest extends Component {
             });
     }
 
+    componentWillUnmount() {
+        this.isEmergency = false;
+    }
+
     render() {
         return (
             <div> 
@@ -338,9 +342,10 @@ class RecurringPickupRequest extends Component {
                                         onToggle={(value) => {
                                             this.setState({
                                                 value: !value,
+                                                isEmergency: !this.state.isEmergency,
                                                 
                                             });
-                                            this.setState({isEmergency: !this.state.isEmergency});
+                                            {/*this.setState({isEmergency: !this.state.isEmergency});*/}
                                         }} 
                                     /> 
                                 </div>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -11,6 +11,8 @@ import './RequestPickup.css';
 import PickupSummary from './PickupSummary.js';
 import PickupRequestedConfirmation from './PickupRequestedConfirmation';
 import moment from 'moment-timezone';
+import Switch from "react-toggle-switch";
+import ToggleButton from 'react-toggle-button'
 
 class RecurringPickupRequest extends Component {
     constructor(props) {
@@ -38,6 +40,7 @@ class RecurringPickupRequest extends Component {
         this.toggleModal = this.toggleModal.bind(this);
         this.addListToState = this.addListToState.bind(this);
         this.closeConfirm = this.closeConfirm.bind(this);
+
     }
 
     // Query DB to populate lists in this.state
@@ -312,236 +315,270 @@ class RecurringPickupRequest extends Component {
 
     render() {
         return (
-            <div className="form">
-                <form id={this.formId} onSubmit={this.createRequest}>
-                    <div className="info">
-                        <p id="form-heading">Schedule Recurring Pickup</p>
-                        {Object.keys(this.state.errors).map((error, i) => {
-                            return (
-                                <p className="error" key={i}>
-                                    {this.state.errors[error]}
-                                </p>
-                            );
-                        })}
-                        <span className="flex">
-                            <span className="grid">
-                                <label>
-                                    Start Date <span className="red">*</span>
-                                </label>
-                                <br />
-                                <input
-                                    type="date"
-                                    name="startDate"
-                                    onChange={this.handleChange.bind(
-                                        this,
-                                        'startDate'
-                                    )}
-                                    required
-                                />
-                                <br />
-                            </span>
-                            <span className="grid">
-                                <label>
-                                    {' '}
-                                    End Criteria <span className="red">*</span>
-                                </label>
-                                <br />
-                                <label className="container-smaller">
+            <div> 
+                <div className="form">
+                    {/* <div className = "toggle"> 
+                        <input type="item" value="Emergency" />
+                        <input type="item" value="Regular" />
+                    </div>} */}
+                   { /*<label>*/}
+
+                    <div className= "toggle">
+                        <span>Regular</span>
+                        <div className="button">
+                        <ToggleButton className="button"
+                                inactiveLabel={""}
+                                activeLabel={""}
+                                colors={{
+                                    active: {
+                                        base: '#e60000',
+                                    },
+                                    inactive: {
+                                        base: 'rgb(0, 153, 51)',
+                                    }
+                                }}
+                                value={this.state.value}
+                                onToggle={(value) => {
+                                    this.setState({
+                                        value: !value,
+
+                                    })
+                                }} 
+                            /> 
+                            </div>
+                            <span> Emergency</span>
+
+                    </div>
+                    {/*</label>*/}
+                    <form id={this.formId} onSubmit={this.createRequest}>
+                        <div className="info">
+                            <p id="form-heading">Schedule Recurring Pickup</p>
+                            {Object.keys(this.state.errors).map((error, i) => {
+                                return (
+                                    <p className="error" key={i}>
+                                        {this.state.errors[error]}
+                                    </p>
+                                );
+                            })}
+                            <span className="flex">
+                                <span className="grid">
+                                    <label>
+                                        Start Date <span className="red">*</span>
+                                    </label>
+                                    <br />
                                     <input
-                                        type="radio"
-                                        name="endCriteria"
-                                        value={RequestEndCriteriaType.OCCUR}
+                                        type="date"
+                                        name="startDate"
                                         onChange={this.handleChange.bind(
                                             this,
-                                            'endCriteria'
+                                            'startDate'
                                         )}
                                         required
                                     />
-                                    <span className="checkmark" />After{' '}
-                                    <input
-                                        type="number"
-                                        name="numOccurrences"
-                                        onChange={this.handleChange.bind(
-                                            this,
-                                            'occurTimes'
-                                        )}
-                                    />{' '}
-                                    times<br />
-                                </label>
-                                <label className="container-smaller">
-                                    <input
-                                        type="radio"
-                                        name="endCriteria"
-                                        value={RequestEndCriteriaType.DATE}
-                                        onChange={this.handleChange.bind(
-                                            this,
-                                            'endCriteria'
-                                        )}
-                                    />
-                                    <span className="checkmark" />End on
-                                    <input
-                                        type="date"
-                                        name="endDate"
-                                        onChange={this.handleChange.bind(
-                                            this,
-                                            'endDate'
-                                        )}
-                                    />
-                                </label>
-                                <br />
+                                    <br />
+                                </span>
+                                <span className="grid">
+                                    <label>
+                                        {' '}
+                                        End Criteria <span className="red">*</span>
+                                    </label>
+                                    <br />
+                                    <label className="container-smaller">
+                                        <input
+                                            type="radio"
+                                            name="endCriteria"
+                                            value={RequestEndCriteriaType.OCCUR}
+                                            onChange={this.handleChange.bind(
+                                                this,
+                                                'endCriteria'
+                                            )}
+                                            required
+                                        />
+                                        <span className="checkmark" />After{' '}
+                                        <input
+                                            type="number"
+                                            name="numOccurrences"
+                                            onChange={this.handleChange.bind(
+                                                this,
+                                                'occurTimes'
+                                            )}
+                                        />{' '}
+                                        times<br />
+                                    </label>
+                                    <label className="container-smaller">
+                                        <input
+                                            type="radio"
+                                            name="endCriteria"
+                                            value={RequestEndCriteriaType.DATE}
+                                            onChange={this.handleChange.bind(
+                                                this,
+                                                'endCriteria'
+                                            )}
+                                        />
+                                        <span className="checkmark" />End on
+                                        <input
+                                            type="date"
+                                            name="endDate"
+                                            onChange={this.handleChange.bind(
+                                                this,
+                                                'endDate'
+                                            )}
+                                        />
+                                    </label>
+                                    <br />
+                                </span>
                             </span>
-                        </span>
-                        <span className="flex">
-                            <span className="grid">
-                                <label>
-                                    Repeats <span className="red">*</span>
-                                </label>
-                                <br />
-                                <select name="repeats" defaultValue="" required>
-                                    <option value="" disabled>
-                                        Select
-                                    </option>
-                                    <option value={RequestRepeatType.WEEKLY}>
-                                        Weekly
-                                    </option>
-                                    <option value={RequestRepeatType.BIWEEKLY}>
-                                        Every other week
-                                    </option>
-                                    {/* TODO warning if not every month in the range has this date */}
-                                    {/* <option value={RequestRepeatType.MONTHLY}>Monthly</option> */}
-                                    {/* (TODO SPR18) Nth Weekday of Month */}
-                                    {/* <option value={RequestRepeatType.??}>Monthly, on the ith of X</option> */}
-                                </select>
-                                <br />
-                            </span>
-                            <span className="grid">
-                                <label>
-                                    Primary Contact{' '}
-                                    <span className="red">*</span>
-                                </label>
-                                <br />
-                                <select
-                                    name="primaryContact"
-                                    defaultValue=""
-                                    required
-                                >
-                                    <option value="" disabled>
-                                        Select
-                                    </option>
-                                    {this.state.memberList.map((member, i) => {
-                                        return (
-                                            <option key={i} value={i}>
-                                                {member.name}
-                                            </option>
-                                        );
-                                    })}
-                                </select>
-                                <br />
-                            </span>
-                        </span>
-                        <span className="flex">
-                            <span className="grid">
-                                <label>
-                                    Start Time <span className="red">*</span>
-                                </label>
-                                <br />
-                                <input
-                                    type="time"
-                                    name="startTime"
-                                    onChange={this.handleChange.bind(
-                                        this,
-                                        'startTime'
-                                    )}
-                                    required
-                                />
-                            </span>
-                            <span className="grid">
-                                <label>
-                                    End Time <span className="red">*</span>
-                                </label>
-                                <br />
-                                <input
-                                    type="time"
-                                    name="endTime"
-                                    onChange={this.handleChange.bind(
-                                        this,
-                                        'endTime'
-                                    )}
-                                    required
-                                />
-                            </span>
-                        </span>
-                        <span className="grid">
-                            <p id="form-heading">Notes for Pickup</p>
-                            <textarea
-                                name="notes"
-                                placeholder="Ex: Use the underground parking garage upon entrance. Key card access required after 3:00pm."
-                            />
-                        </span>
-                        <p id="form-heading">Agencies involved</p>
-                        <span className="flex">
-                            <span className="grid">
-                                <label>Student Group</label>
-                                <br />
-                                <select name="delivererGroup" defaultValue="">
-                                    <option value="">Select</option>
-                                    {this.state.delivererGroups.map((dg, i) => {
-                                        return (
-                                            <option key={i} value={i}>
-                                                {dg.name}
-                                            </option>
-                                        );
-                                    })}
-                                </select>
-                            </span>
-                            <span className="grid">
-                                <label>Shelter</label>
-                                <br />
-                                <select name="receivingAgency" defaultValue="">
-                                    <option value="">Select</option>
-                                    {this.state.receivingAgencies.map(
-                                        (ra, i) => {
+                            <span className="flex">
+                                <span className="grid">
+                                    <label>
+                                        Repeats <span className="red">*</span>
+                                    </label>
+                                    <br />
+                                    <select name="repeats" defaultValue="" required>
+                                        <option value="" disabled>
+                                            Select
+                                        </option>
+                                        <option value={RequestRepeatType.WEEKLY}>
+                                            Weekly
+                                        </option>
+                                        <option value={RequestRepeatType.BIWEEKLY}>
+                                            Every other week
+                                        </option>
+                                        {/* TODO warning if not every month in the range has this date */}
+                                        {/* <option value={RequestRepeatType.MONTHLY}>Monthly</option> */}
+                                        {/* (TODO SPR18) Nth Weekday of Month */}
+                                        {/* <option value={RequestRepeatType.??}>Monthly, on the ith of X</option> */}
+                                    </select>
+                                    <br />
+                                </span>
+                                <span className="grid">
+                                    <label>
+                                        Primary Contact{' '}
+                                        <span className="red">*</span>
+                                    </label>
+                                    <br />
+                                    <select
+                                        name="primaryContact"
+                                        defaultValue=""
+                                        required
+                                    >
+                                        <option value="" disabled>
+                                            Select
+                                        </option>
+                                        {this.state.memberList.map((member, i) => {
                                             return (
                                                 <option key={i} value={i}>
-                                                    {ra.name}
+                                                    {member.name}
                                                 </option>
                                             );
-                                        }
-                                    )}
-                                </select>
+                                        })}
+                                    </select>
+                                    <br />
+                                </span>
                             </span>
-                        </span>
-                        <div className="buttons-form">
-                            <input type="submit" value="Done" />
-                            <input type="reset" value="Cancel" />
+                            <span className="flex">
+                                <span className="grid">
+                                    <label>
+                                        Start Time <span className="red">*</span>
+                                    </label>
+                                    <br />
+                                    <input
+                                        type="time"
+                                        name="startTime"
+                                        onChange={this.handleChange.bind(
+                                            this,
+                                            'startTime'
+                                        )}
+                                        required
+                                    />
+                                </span>
+                                <span className="grid">
+                                    <label>
+                                        End Time <span className="red">*</span>
+                                    </label>
+                                    <br />
+                                    <input
+                                        type="time"
+                                        name="endTime"
+                                        onChange={this.handleChange.bind(
+                                            this,
+                                            'endTime'
+                                        )}
+                                        required
+                                    />
+                                </span>
+                            </span>
+                            <span className="grid">
+                                <p id="form-heading">Notes for Pickup</p>
+                                <textarea
+                                    name="notes"
+                                    placeholder="Ex: Use the underground parking garage upon entrance. Key card access required after 3:00pm."
+                                />
+                            </span>
+                            <p id="form-heading">Agencies involved</p>
+                            <span className="flex">
+                                <span className="grid">
+                                    <label>Student Group</label>
+                                    <br />
+                                    <select name="delivererGroup" defaultValue="">
+                                        <option value="">Select</option>
+                                        {this.state.delivererGroups.map((dg, i) => {
+                                            return (
+                                                <option key={i} value={i}>
+                                                    {dg.name}
+                                                </option>
+                                            );
+                                        })}
+                                    </select>
+                                </span>
+                                <span className="grid">
+                                    <label>Shelter</label>
+                                    <br />
+                                    <select name="receivingAgency" defaultValue="">
+                                        <option value="">Select</option>
+                                        {this.state.receivingAgencies.map(
+                                            (ra, i) => {
+                                                return (
+                                                    <option key={i} value={i}>
+                                                        {ra.name}
+                                                    </option>
+                                                );
+                                            }
+                                        )}
+                                    </select>
+                                </span>
+                            </span>
+                            <div className="buttons-form">
+                                <input type="submit" value="Done" />
+                                <input type="reset" value="Cancel" />
+                            </div>
                         </div>
-                    </div>
-                </form>
+                    </form>
 
-                {this.state.showPopup && (
-                    <PickupSummary
-                        title={'Request Recurring Pickup'}
-                        request={this.state.request}
-                        donatingAgency={this.props.donatingAgency}
-                        primaryContact={this.state.primaryContact}
-                        raRequested={this.state.raRequested}
-                        dgRequested={this.state.dgRequested}
-                        onClose={this.toggleModal}
-                        onConfirm={this.submitRequest}
-                        submissionError={this.state.submissionError}
-                    />
-                )}
-                {this.state.showConfirmation && (
-                    <PickupRequestedConfirmation
-                        request={this.state.request}
-                        closeConfirm={this.closeConfirm}
-                        donatingAgency={this.props.donatingAgency}
-                        raRequested={this.state.raRequested}
-                    />
-                )}
+                    {this.state.showPopup && (
+                        <PickupSummary
+                            title={'Request Recurring Pickup'}
+                            request={this.state.request}
+                            donatingAgency={this.props.donatingAgency}
+                            primaryContact={this.state.primaryContact}
+                            raRequested={this.state.raRequested}
+                            dgRequested={this.state.dgRequested}
+                            onClose={this.toggleModal}
+                            onConfirm={this.submitRequest}
+                            submissionError={this.state.submissionError}
+                        />
+                    )}
+                    {this.state.showConfirmation && (
+                        <PickupRequestedConfirmation
+                            request={this.state.request}
+                            closeConfirm={this.closeConfirm}
+                            donatingAgency={this.props.donatingAgency}
+                            raRequested={this.state.raRequested}
+                        />
+                    )}
+                </div>
             </div>
         );
     }
 }
-
 export default RecurringPickupRequest;

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -340,13 +340,13 @@ class RecurringPickupRequest extends Component {
                                             this.setState({
                                                 value: !value,
                                                 
-                                            })
+                                            });
                                             this.state.isEmergency = !this.state.isEmergency;
                                         }} 
                                     /> 
                                 </div>
                                 <span>Emergency</span>
-                             </label>
+                            </label>
                             <p id="form-heading">Schedule Recurring Pickup</p>
                             {Object.keys(this.state.errors).map((error, i) => {
                                 return (

--- a/src/PageContent/RequestPickup/RequestPickup.css
+++ b/src/PageContent/RequestPickup/RequestPickup.css
@@ -166,12 +166,15 @@ input[type="radio"]{
     float: right;
     padding-top: 20px;
 }
+
 .button {
-    padding: 5px;
+    padding-left: 5px;
+    padding-right: 5px;
 }
+
 .toggle {
-    padding-left: 380px;
-    width:100px;
+    padding-left: 350px;
+    width:90px;
     margin: 0;
     display: flex;
 }

--- a/src/PageContent/RequestPickup/RequestPickup.css
+++ b/src/PageContent/RequestPickup/RequestPickup.css
@@ -170,6 +170,7 @@ input[type="radio"]{
 .button {
     padding-left: 5px;
     padding-right: 5px;
+    width: 10px;
 
 }
 

--- a/src/PageContent/RequestPickup/RequestPickup.css
+++ b/src/PageContent/RequestPickup/RequestPickup.css
@@ -170,11 +170,12 @@ input[type="radio"]{
 .button {
     padding-left: 5px;
     padding-right: 5px;
+
 }
 
 .toggle {
     padding-left: 350px;
-    width:90px;
+    width: 100px;
     margin: 0;
     display: flex;
 }

--- a/src/PageContent/RequestPickup/RequestPickup.css
+++ b/src/PageContent/RequestPickup/RequestPickup.css
@@ -175,9 +175,8 @@ input[type="radio"]{
 
 .toggle {
     padding-left: 350px;
-    width: 100px;
-    margin: 0;
     display: flex;
+    height: 30px;
 }
 
 input[value="Emergency"] {

--- a/src/PageContent/RequestPickup/RequestPickup.css
+++ b/src/PageContent/RequestPickup/RequestPickup.css
@@ -166,6 +166,19 @@ input[type="radio"]{
     float: right;
     padding-top: 20px;
 }
+.button {
+    padding: 5px;
+}
+.toggle {
+    padding-left: 380px;
+    width:100px;
+    margin: 0;
+    display: flex;
+}
+
+input[value="Emergency"] {
+    background-color: #e60000;
+}
 
 input[value="Cancel"]{
     color: #BDBDBD;
@@ -210,6 +223,10 @@ input[type="date"]::-webkit-calendar-picker-indicator{
     color:#F77676;
     margin: 0px;
     visibility: show;
+}
+
+.header {
+
 }
 
 @media screen and (max-width: 1090px) {


### PR DESCRIPTION
<b>Changes:</b> 
Added a toggle to top of request pickup form that slides between regular and emergency status. Not functional yet.

<img width="249" alt="screen shot 2018-11-01 at 2 21 14 pm" src="https://user-images.githubusercontent.com/26514719/47880985-1a656480-dde2-11e8-9bfa-8d8ea48e6f7d.png">
<img width="247" alt="screen shot 2018-11-01 at 2 21 20 pm" src="https://user-images.githubusercontent.com/26514719/47880993-1fc2af00-dde2-11e8-84c6-ae75aec8388c.png">

<b>TODO:</b>
Make functional, so different form probably for "emergency" status.




