### PR TITLE
Calendar emergency pickup

### DIFF
--- a/src/PageContent/Calendar/Dialog.js
+++ b/src/PageContent/Calendar/Dialog.js
@@ -16,6 +16,7 @@ class Dialog extends Component {
                         endTime={this.props.delivery.endTimestamp}
                         futureEvent={this.props.futureEvent}
                         accountType={this.props.account.accountType}
+                        delivery={this.props.delivery}
                     />
                     <DialogContent
                         futureEvent={this.props.futureEvent}

--- a/src/PageContent/Calendar/EventCard/EventCard.css
+++ b/src/PageContent/Calendar/EventCard/EventCard.css
@@ -18,6 +18,16 @@
   border-left: 3.8px solid #2ecc71;
 }
 
+.event-container-emergency-future {
+  background-color: rgba(204, 46, 46, 0.1);
+  border-left: 3.8px solid #cc2e2e;
+}
+
+.event-container-emergency-future-clicked {
+  background-color: #cc2e2e;
+  border-left: 3.8px solid #cc2e2e;
+}
+
 .event-container-past {
   background-color: #eef1f7;
   border-left: 3.8px solid #8c97b2;

--- a/src/PageContent/Calendar/EventCard/EventCard.js
+++ b/src/PageContent/Calendar/EventCard/EventCard.js
@@ -45,7 +45,7 @@ class EventCard extends Component {
             (account.accountType === AccountType.DONATING_AGENCY_MEMBER &&
                 (!delivery.description || !delivery.description.foodItems)));
 
-        let emergencyDelivery = delivery.type === "emergency"
+        let emergencyDelivery = delivery.type === "emergency";
 
         if (futureEvent) {
             //If it is an emergency delivery use .event-container-emergency-future class

--- a/src/PageContent/Calendar/EventCard/EventCard.js
+++ b/src/PageContent/Calendar/EventCard/EventCard.js
@@ -45,7 +45,7 @@ class EventCard extends Component {
             (account.accountType === AccountType.DONATING_AGENCY_MEMBER &&
                 (!delivery.description || !delivery.description.foodItems)));
 
-        let emergencyDelivery = delivery.type === "emergency";
+        let emergencyDelivery = delivery.type === 'emergency';
 
         if (futureEvent) {
             //If it is an emergency delivery use .event-container-emergency-future class
@@ -56,7 +56,7 @@ class EventCard extends Component {
                 iconAlt = 'plus';
                 iconClass += 'eventcard-plus-icon';
             } else if (emergencyDelivery) {
-                icon = red_truck
+                icon = red_truck;
                 iconAlt = 'red truck';
                 iconClass += 'truck-icon';
             } else {
@@ -110,18 +110,18 @@ class EventCard extends Component {
                         </div>
                     </div>
                 ) : (
-                        <div className={style} onClick={this.openDialog}>
-                            <h1 className="event-header">Reccuring Pick Up</h1>
-                            <img
-                                className={iconClass}
-                                src={icon}
-                                alt={iconAlt}
-                            />
-                            <p className="event-time">
-                                {startTime} - {endTime}
-                            </p>
-                        </div>
-                    )}
+                    <div className={style} onClick={this.openDialog}>
+                        <h1 className="event-header">Reccuring Pick Up</h1>
+                        <img
+                            className={iconClass}
+                            src={icon}
+                            alt={iconAlt}
+                        />
+                        <p className="event-time">
+                            {startTime} - {endTime}
+                        </p>
+                    </div>
+                )}
             </div>
         );
     }

--- a/src/PageContent/Calendar/EventCard/EventCard.js
+++ b/src/PageContent/Calendar/EventCard/EventCard.js
@@ -3,6 +3,7 @@ import './EventCard.css';
 import green_truck from '../../../icons/green_truck.svg';
 import grey_truck from '../../../icons/grey_truck.svg';
 import white_truck from '../../../icons/white_truck.svg';
+import red_truck from '../../../icons/red_truck.svg';
 import plus from '../../../icons/plus-button.svg';
 import moment from 'moment';
 import { AccountType, StringFormat } from '../../../Enums';
@@ -38,18 +39,26 @@ class EventCard extends Component {
         let iconClass = 'eventcard-icon ';
         let style = 'event-container ';
         let futureEvent = moment(delivery.startTimestamp).isAfter(moment());
+
         let actionNeeded = futureEvent && (
             (account.accountType === AccountType.DELIVERER_GROUP && !delivery.deliverers) ||
-            (account.accountType === AccountType.DONATING_AGENCY_MEMBER && 
+            (account.accountType === AccountType.DONATING_AGENCY_MEMBER &&
                 (!delivery.description || !delivery.description.foodItems)));
 
+        let emergencyDelivery = delivery.type === "emergency"
+
         if (futureEvent) {
-            style += 'event-container-future';
+            //If it is an emergency delivery use .event-container-emergency-future class
+            emergencyDelivery ? style += 'event-container-emergency-future' : style += 'event-container-future';
             if (actionNeeded) {
                 // use red plus icon if an action is required for this delivery
                 icon = plus;
                 iconAlt = 'plus';
                 iconClass += 'eventcard-plus-icon';
+            } else if (emergencyDelivery) {
+                icon = red_truck
+                iconAlt = 'red truck';
+                iconClass += 'truck-icon';
             } else {
                 icon = green_truck;
                 iconAlt = 'green truck';
@@ -101,18 +110,18 @@ class EventCard extends Component {
                         </div>
                     </div>
                 ) : (
-                    <div className={style} onClick={this.openDialog}>
-                        <h1 className="event-header">Reccuring Pick Up</h1>
-                        <img
-                            className={iconClass}
-                            src={icon}
-                            alt={iconAlt}
-                        />
-                        <p className="event-time">
-                            {startTime} - {endTime}
-                        </p>
-                    </div>
-                )}
+                        <div className={style} onClick={this.openDialog}>
+                            <h1 className="event-header">Reccuring Pick Up</h1>
+                            <img
+                                className={iconClass}
+                                src={icon}
+                                alt={iconAlt}
+                            />
+                            <p className="event-time">
+                                {startTime} - {endTime}
+                            </p>
+                        </div>
+                    )}
             </div>
         );
     }

--- a/src/PageContent/Calendar/Header.css
+++ b/src/PageContent/Calendar/Header.css
@@ -29,8 +29,13 @@
 .past-header {
   background-color: #8c97b2;
 }
+
 .future-header {
   background-color: #2ecc71;
+}
+
+.emergency-header {
+  background-color: #F77676;
 }
 .header-time {
   padding: 0px;

--- a/src/PageContent/Calendar/Header.js
+++ b/src/PageContent/Calendar/Header.js
@@ -15,7 +15,11 @@ class Header extends Component {
 
         let headerClass = '';
         if (this.props.futureEvent) {
-            headerClass = 'header future-header';
+            if (this.props.delivery.type === 'emergency') {
+                headerClass = 'header emergency-header';
+            } else {
+                headerClass = 'header future-header';
+            }
         } else {
             headerClass = 'header past-header';
         }


### PR DESCRIPTION
Adding emergency pickups to the calendar

### List of changes
I added some conditionals to check if the delivery type is emergency and based off of that different styles are shown. In this PR I added red to the calendar events and the top header of the modal when you click on the event for emergency pickups.

### What you did to test it
I manually tested it by changing the type of the delivery, checking if the colors updated correctly, and making sure everything else on the page still functioned as usual.