### PR TITLE
Feature past pickups editable

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ class App extends Component {
             signInDenied: false,
             account: null,
             donatingAgency: null,
-            isChrome: !!window.chrome && !!window.chrome.webstore
+            isChrome: !!window.chrome //&& !!window.chrome.webstore
         };
 
         this.aggrAccount = this.aggrAccount.bind(this);
@@ -141,7 +141,7 @@ class App extends Component {
                         WARNING! You are using an UNSUPPORTED browser. Please use Google Chrome.
                         </div>
                         :
-                        document.documentElement.clientWidth < 1400 ?
+                        document.documentElement.clientWidth < 1000 ?
                             <div className="browser-check">
                         WARNING! Your browser is too small, use at your own risk.
                             </div>

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -121,8 +121,7 @@ class DescriptionContent extends Component {
             // record timestamp of when the write was done
             this.setState({ savedTimestamp: moment().valueOf() });
             this.setState({ isWaitingNotes: false, isEditingNotes: false }); 
-        });
-        //this.setState({ waiting: false, isEditingNotes: false });    
+        });  
     }
 
     saveFoodItems(e) {
@@ -192,9 +191,9 @@ class DescriptionContent extends Component {
         }
 
         let isEditableFood = (accountType === AccountType.DONATING_AGENCY_MEMBER &&
-            !this.state.isEditingFoodItems && futureEvent);
+            !this.state.isEditingFoodItems);
         let isEditableNotes = (accountType === AccountType.DONATING_AGENCY_MEMBER &&
-            !this.state.isEditingNotes && futureEvent);
+            !this.state.isEditingNotes);
 
         return (
             <div className="wrapper">
@@ -266,7 +265,7 @@ class DescriptionContent extends Component {
                                             className="description-edit-button"
                                             value={this.state.isWaitingFood ? 'saving...' : 'save'}
                                         />
-                                    </div>   
+                                    </div>
                                 </fieldset>
                             </form>
                         </div>

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -12,7 +12,8 @@ class DescriptionContent extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            edit: false,
+            isEditingFoodItems: false,
+            isEditingNotes: false,
             // 'waiting' is true after 'Saved' is clicked and before changes
             // from db is propagated down. While it is true, input fields are
             // disabled
@@ -21,7 +22,8 @@ class DescriptionContent extends Component {
             foodRows: null, // for rendering editable rows only
         };
 
-        this.edit = this.edit.bind(this);
+        this.editNotes = this.editNotes.bind(this);
+        this.editFoodItems = this.editFoodItems.bind(this);
         this.saveFoodItems = this.saveFoodItems.bind(this);
         this.addRow = this.addRow.bind(this);
     }
@@ -30,11 +32,18 @@ class DescriptionContent extends Component {
         // update state to reflect values properly saved if we were waiting
         // on the update and the update happened after we wrote to db.
         if (this.state.waiting && nextProps.delivery.updatedTimestamp > this.state.savedTimestamp) {
-            this.setState({ waiting: false, edit: false, foodRows: null });
+            this.setState({ waiting: false, isEditingFoodItems: false, foodRows: null });
         }
     }
 
-    edit() {
+    editNotes() {
+        {/*const notes = this.props.delivery.notes;*/}
+        this.setState({
+            isEditingNotes: true,
+        });
+    }
+
+    editFoodItems() {
         const description = this.props.delivery.description;
 
         // copy current food items into state for editing purposes
@@ -44,14 +53,14 @@ class DescriptionContent extends Component {
         }
 
         this.setState({
-            edit: true,
+            isEditingFoodItems: true,
             foodRows: foodRows,
         });
     }
 
     addRow() {
-        if (!this.state.edit) {
-            this.edit();
+        if (!this.state.isEditingFoodItems) {
+            this.editFoodItems();
         }
 
         this.setState(prevState => {
@@ -119,7 +128,7 @@ class DescriptionContent extends Component {
             });
         } else {
             //nothing changed
-            this.setState({ waiting: false, edit: false });
+            this.setState({ waiting: false, isEditingFoodItems: false });
         }
     }
 
@@ -161,7 +170,7 @@ class DescriptionContent extends Component {
         }
 
         let editable = (accountType === AccountType.DONATING_AGENCY_MEMBER &&
-            !this.state.edit && futureEvent);
+            !this.state.isEditingFoodItems && futureEvent);
 
         return (
             <div className="wrapper">
@@ -176,7 +185,7 @@ class DescriptionContent extends Component {
                     }
 
 
-                    {!this.state.edit ? (
+                    {!this.state.isEditingFoodItems ? (
                         <div>
                             {description && description.foodItems ? (
                                 <div>
@@ -190,7 +199,7 @@ class DescriptionContent extends Component {
                                         </p>
                                     </div>
                                     {editable &&
-                                        <button type="button" className="edit-button" onClick={this.edit}>
+                                        <button type="button" className="edit-button" onClick={this.editFoodItems}>
                                             Edit
                                         </button>
                                     }
@@ -239,17 +248,35 @@ class DescriptionContent extends Component {
                     )}
                 </div>
                {/*} <img className="content-icon" src={notes} alt="notes" />*/}
-                <div className="content-details-wrapper">
-                    <h1 className="section-header">Notes for Pickup</h1>
-                    <p>{delivery.notes}</p>
-                    {/*if (accountType === AccountType.DONATING_AGENCY_MEMBER) {*/}
-                    {/*{editable &&*/}
-                    {accountType === AccountType.DONATING_AGENCY_MEMBER &&
-                        <button type="button" className="edit-button">
-                            Edit
-                        </button>
-                    }  
-                </div>
+                {!this.state.isEditingNotes ? (
+                    <div>
+                        <div className="content-details-wrapper">
+                            <h1 className="section-header">Notes for Pickup</h1>
+                            <p>{delivery.notes}</p>
+                            {/*if (accountType === AccountType.DONATING_AGENCY_MEMBER) {*/}
+                            {/*{editable &&*/}
+                        </div>
+                        {accountType === AccountType.DONATING_AGENCY_MEMBER &&
+                            <button type="button" className="edit-button" onClick={this.editNotes}>
+                                Edit
+                            </button>
+                        }
+                    </div>
+                ) : (
+                    <div className="content-details-wrapper">
+                        <form className="edit-dg" onSubmit={this.saveNotes}>
+                            <textarea value={delivery.notes}/>
+                            
+                            <div className="save-button-wrapper">
+                                <input
+                                    type="submit"
+                                    className="description-edit-button"
+                                    value={this.state.waiting ? 'saving...' : 'save'}
+                                />
+                            </div> 
+                        </form>
+                    </div>
+                )} 
             </div>
         );
     }

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -77,8 +77,6 @@ class DescriptionContent extends Component {
     }
 
     getEditNotes(e) {
-        // console.log(e.target.value);
-        // console.log(this.state.currentNote)
         this.setState({currentNote: e.target.value});
     }
 
@@ -119,7 +117,6 @@ class DescriptionContent extends Component {
         this.setState({ waiting: true });
         let updates = {};
         updates['notes'] = this.state.currentNote;
-        // console.log(e.target.value); Not sure why this is undefined?
         deliveriesRef.child(this.props.delivery.id).update(updates).then(() => {
             // record timestamp of when the write was done
             this.setState({ savedTimestamp: moment().valueOf() });
@@ -199,7 +196,7 @@ class DescriptionContent extends Component {
 
         return (
             <div className="wrapper">
-                // FOOD ITEMS
+                {/*FOOD ITEMS/*}
                 <img className="content-icon groceries" src={groceries} alt="volunteer" />
                 <div className="content-wrapper content-wrapper-description">
                     <h1 className="section-header">Donation Description</h1>
@@ -274,7 +271,7 @@ class DescriptionContent extends Component {
                     )}
                 </div>
 
-                // NOTES
+                {/*NOTES*/}
                 <img className="content-icon" src={notes} alt="notes"/>
                 <div className="content-wrapper content-wrapper-description">
                     <h1 className="section-header">Notes for Pickup</h1>

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -276,23 +276,21 @@ class DescriptionContent extends Component {
                         
                     {!this.state.isEditingNotes ? (
                         <div>
-                            {delivery.notes ? (
-                                <div>
-                                    <div className="content-details-wrapper">
-                                        <p className="content-details description-content">
-                                            {delivery.notes}
-                                        </p>
-                                    </div>
-                                    {/*{accountType === AccountType.DONATING_AGENCY_MEMBER */}
-                                    {editable &&
-                                        <button type="button" className="edit-button" onClick={this.editNotes}>
-                                            Edit
-                                        </button>
-                                    }
-                                </div>
-                            ) : (
-                                <p>Left empty</p>
-                            )}{' '}
+                            <div className="content-details-wrapper">
+                                {delivery.notes ? (
+                                    <p className="content-details description-content">
+                                        {delivery.notes}
+                                    </p>
+                                        
+                                ) : (
+                                    <p>Left empty</p>
+                                )}{' '}
+                            </div>
+                            {editable &&
+                                <button type="button" className="edit-button" onClick={this.editNotes}>
+                                    Edit
+                                </button>
+                            }
                         </div>
                     ) : (
                         <div className="content-details-wrapper">

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -272,20 +272,15 @@ class DescriptionContent extends Component {
                         </div>
                     )}
                 </div>
-               {/*} <img className="content-icon" src={notes} alt="notes" />*/}
+               {/*<img className="content-icon" src={notes} alt="notes"/>
                 {!this.state.isEditingNotes ? (
                     <div>
                         <div className="content-details-wrapper">
                             <h1 className="section-header">Notes for Pickup</h1>
                             <p>{delivery.notes}</p>
-                            {/*if (accountType === AccountType.DONATING_AGENCY_MEMBER) {*/}
-                            {/*{editable &&*/}
                         </div>
-                        {accountType === AccountType.DONATING_AGENCY_MEMBER &&
-                            <button type="button" className="edit-button" onClick={this.editNotes}>
-                                Edit
-                            </button>
-                        }
+                        
+
                     </div>
                 ) : (
                     <div className="content-details-wrapper">
@@ -306,6 +301,47 @@ class DescriptionContent extends Component {
 
                     </div>
                 )} 
+            </div>*/}
+                <img className="content-icon" src={notes} alt="notes"/>
+                <div className="content-wrapper content-wrapper-description">
+                    <h1 className="section-header">Notes for Pickup</h1>
+
+                        {!this.state.isEditingNotes ? (
+                            <div>
+                                {delivery.notes ? (
+                                    <div>
+                                        <div className="content-details-wrapper">
+                                            <p className="content-details description-content">
+                                                {delivery.notes}
+                                            </p>
+                                        </div>
+                                        {accountType === AccountType.DONATING_AGENCY_MEMBER &&
+                                            <button type="button" className="edit-button" onClick={this.editNotes}>
+                                                Edit
+                                            </button>
+                                        }
+                                    </div>
+                                ) : (
+                                    <p>Left empty</p>
+                                )}{' '}
+                            </div>
+                        ) : (
+                            <div className="content-details-wrapper">
+                                <form className="edit-dg" onSubmit={this.saveNotes}>
+                                    <div className="input-wrapper">
+                                        <textarea value={this.state.currentNote} onChange={this.getEditNotes}/>
+                                    </div>
+                                    <div className="save-button-wrapper">
+                                        <input
+                                            type="submit"
+                                            className="description-edit-button"
+                                            value={this.state.waiting ? 'saving...' : 'save'}
+                                        />
+                                    </div>
+                                </form>
+                            </div>
+                        )}
+                    </div>
             </div>
         );
     }

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -4,6 +4,7 @@ import { AccountType, FoodUnit, StringFormat } from '../../Enums';
 import { deliveriesRef } from '../../FirebaseConfig';
 import { objectsAreEqual } from '../../utils/Utils';
 import './Content.css';
+import notes from '../../icons/food_logs.svg'
 import groceries from '../../icons/groceries.svg';
 import plus from '../../icons/plus-button.svg';
 
@@ -117,7 +118,7 @@ class DescriptionContent extends Component {
                 this.setState({ savedTimestamp: moment().valueOf() });
             });
         } else {
-            // nothing changed
+            //nothing changed
             this.setState({ waiting: false, edit: false });
         }
     }
@@ -146,6 +147,7 @@ class DescriptionContent extends Component {
         const { account, delivery, futureEvent } = this.props;
         const accountType = account.accountType;
         const description = delivery.description;
+        {/*const notes = delivery.notes;*/}
 
         let lastEdited = null;
         if (accountType === AccountType.DONATING_AGENCY_MEMBER &&
@@ -172,6 +174,7 @@ class DescriptionContent extends Component {
                             {' '}Last edited by {lastEdited.name},{' '}{lastEdited.time}
                         </p>
                     }
+
 
                     {!this.state.edit ? (
                         <div>
@@ -229,11 +232,23 @@ class DescriptionContent extends Component {
                                             className="description-edit-button"
                                             value={this.state.waiting ? 'saving...' : 'save'}
                                         />
-                                    </div>
+                                    </div>   
                                 </fieldset>
                             </form>
                         </div>
                     )}
+                </div>
+               {/*} <img className="content-icon" src={notes} alt="notes" />*/}
+                <div className="content-details-wrapper">
+                    <h1 className="section-header">Notes for Pickup</h1>
+                    <p>{delivery.notes}</p>
+                    {/*if (accountType === AccountType.DONATING_AGENCY_MEMBER) {*/}
+                    {/*{editable &&*/}
+                    {accountType === AccountType.DONATING_AGENCY_MEMBER &&
+                        <button type="button" className="edit-button">
+                            Edit
+                        </button>
+                    }  
                 </div>
             </div>
         );

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -42,7 +42,6 @@ class DescriptionContent extends Component {
     }
     
     editNotes() {
-        {/*const notes = this.props.delivery.notes;*/}
         this.setState({
             isEditingNotes: true,
             currentNote: this.props.delivery.notes,
@@ -178,7 +177,6 @@ class DescriptionContent extends Component {
         const { account, delivery, futureEvent } = this.props;
         const accountType = account.accountType;
         const description = delivery.description;
-        {/*const notes = delivery.notes;*/}
 
         let lastEdited = null;
         if (accountType === AccountType.DONATING_AGENCY_MEMBER &&
@@ -196,7 +194,7 @@ class DescriptionContent extends Component {
 
         return (
             <div className="wrapper">
-                {/*FOOD ITEMS/*}
+                {/*FOOD ITEMS*/}
                 <img className="content-icon groceries" src={groceries} alt="volunteer" />
                 <div className="content-wrapper content-wrapper-description">
                     <h1 className="section-header">Donation Description</h1>

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -4,7 +4,7 @@ import { AccountType, FoodUnit, StringFormat } from '../../Enums';
 import { deliveriesRef } from '../../FirebaseConfig';
 import { objectsAreEqual } from '../../utils/Utils';
 import './Content.css';
-import notes from '../../icons/food_logs.svg'
+import notes from '../../icons/food_logs.svg';
 import groceries from '../../icons/groceries.svg';
 import plus from '../../icons/plus-button.svg';
 
@@ -121,7 +121,7 @@ class DescriptionContent extends Component {
         updates['notes'] = this.state.currentNote;
         // console.log(e.target.value); Not sure why this is undefined?
         deliveriesRef.child(this.props.delivery.id).update(updates).then(() => {
-                // record timestamp of when the write was done
+            // record timestamp of when the write was done
             this.setState({ savedTimestamp: moment().valueOf() });
         });
         this.setState({ waiting: false, isEditingNotes: false });    
@@ -195,10 +195,11 @@ class DescriptionContent extends Component {
         }
 
         let editable = (accountType === AccountType.DONATING_AGENCY_MEMBER &&
-            !this.state.isEditingFoodItems && futureEvent);
+            !this.state.isEditingFoodItems && !this.state.isEditingNotes && futureEvent);
 
         return (
             <div className="wrapper">
+                // FOOD ITEMS
                 <img className="content-icon groceries" src={groceries} alt="volunteer" />
                 <div className="content-wrapper content-wrapper-description">
                     <h1 className="section-header">Donation Description</h1>
@@ -272,76 +273,49 @@ class DescriptionContent extends Component {
                         </div>
                     )}
                 </div>
-               {/*<img className="content-icon" src={notes} alt="notes"/>
-                {!this.state.isEditingNotes ? (
-                    <div>
-                        <div className="content-details-wrapper">
-                            <h1 className="section-header">Notes for Pickup</h1>
-                            <p>{delivery.notes}</p>
-                        </div>
-                        
 
-                    </div>
-                ) : (
-                    <div className="content-details-wrapper">
-                        <form className="edit-dg" onSubmit={this.saveNotes}>
-                            <div className="input-wrapper">
-
-                                <textarea value={this.state.currentNote} onChange={this.getEditNotes}/>
-
-                            </div>
-                            <div className="save-button-wrapper">
-                                <input
-                                    type="submit"
-                                    className="description-edit-button"
-                                    value={this.state.waiting ? 'saving...' : 'save'}
-                                />
-                            </div>
-                        </form>
-
-                    </div>
-                )} 
-            </div>*/}
+                // NOTES
                 <img className="content-icon" src={notes} alt="notes"/>
                 <div className="content-wrapper content-wrapper-description">
                     <h1 className="section-header">Notes for Pickup</h1>
-
-                        {!this.state.isEditingNotes ? (
-                            <div>
-                                {delivery.notes ? (
-                                    <div>
-                                        <div className="content-details-wrapper">
-                                            <p className="content-details description-content">
-                                                {delivery.notes}
-                                            </p>
-                                        </div>
-                                        {accountType === AccountType.DONATING_AGENCY_MEMBER &&
-                                            <button type="button" className="edit-button" onClick={this.editNotes}>
-                                                Edit
-                                            </button>
-                                        }
+                        
+                    {!this.state.isEditingNotes ? (
+                        <div>
+                            {delivery.notes ? (
+                                <div>
+                                    <div className="content-details-wrapper">
+                                        <p className="content-details description-content">
+                                            {delivery.notes}
+                                        </p>
                                     </div>
-                                ) : (
-                                    <p>Left empty</p>
-                                )}{' '}
-                            </div>
-                        ) : (
-                            <div className="content-details-wrapper">
-                                <form className="edit-dg" onSubmit={this.saveNotes}>
-                                    <div className="input-wrapper">
-                                        <textarea value={this.state.currentNote} onChange={this.getEditNotes}/>
-                                    </div>
-                                    <div className="save-button-wrapper">
-                                        <input
-                                            type="submit"
-                                            className="description-edit-button"
-                                            value={this.state.waiting ? 'saving...' : 'save'}
-                                        />
-                                    </div>
-                                </form>
-                            </div>
-                        )}
-                    </div>
+                                    {/*{accountType === AccountType.DONATING_AGENCY_MEMBER */}
+                                    {editable &&
+                                        <button type="button" className="edit-button" onClick={this.editNotes}>
+                                            Edit
+                                        </button>
+                                    }
+                                </div>
+                            ) : (
+                                <p>Left empty</p>
+                            )}{' '}
+                        </div>
+                    ) : (
+                        <div className="content-details-wrapper">
+                            <form className="edit-dg" onSubmit={this.saveNotes}>
+                                <div className="input-wrapper">
+                                    <textarea value={this.state.currentNote} onChange={this.getEditNotes}/>
+                                </div>
+                                <div className="save-button-wrapper">
+                                    <input
+                                        type="submit"
+                                        className="description-edit-button"
+                                        value={this.state.waiting ? 'saving...' : 'save'}
+                                    />
+                                </div>
+                            </form>
+                        </div>
+                    )}
+                </div>
             </div>
         );
     }

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -14,7 +14,8 @@ class DescriptionContent extends Component {
         this.state = {
             isEditingFoodItems: false,
             isEditingNotes: false,
-            currentNote: null,
+            currentNote: this.props.delivery.notes,
+
 
             // 'waiting' is true after 'Saved' is clicked and before changes
             // from db is propagated down. While it is true, input fields are
@@ -23,7 +24,9 @@ class DescriptionContent extends Component {
             savedTimestamp: null,
             foodRows: null, // for rendering editable rows only
         };
-        this.getEditNotes = this.getEditNotes.bind(this);
+
+        this.saveNotes = this.saveNotes.bind(this);
+        this.getEditNotes = this.getEditNotes.bind(this); // used to get current note in textbox
         this.editNotes = this.editNotes.bind(this);
         this.editFoodItems = this.editFoodItems.bind(this);
         this.saveFoodItems = this.saveFoodItems.bind(this);
@@ -74,8 +77,9 @@ class DescriptionContent extends Component {
     }
 
     getEditNotes(e) {
+        // console.log(e.target.value);
+        // console.log(this.state.currentNote)
         this.setState({currentNote: e.target.value});
-
     }
 
     getEditDonation() {
@@ -110,6 +114,18 @@ class DescriptionContent extends Component {
         });
     }
 
+    saveNotes(e) {
+        e.preventDefault();
+        this.setState({ waiting: true });
+        let updates = {};
+        updates['notes'] = this.state.currentNote;
+        // console.log(e.target.value); Not sure why this is undefined?
+        deliveriesRef.child(this.props.delivery.id).update(updates).then(() => {
+                // record timestamp of when the write was done
+            this.setState({ savedTimestamp: moment().valueOf() });
+        });
+        this.setState({ waiting: false, isEditingNotes: false });    
+    }
 
     saveFoodItems(e) {
         e.preventDefault();
@@ -275,7 +291,9 @@ class DescriptionContent extends Component {
                     <div className="content-details-wrapper">
                         <form className="edit-dg" onSubmit={this.saveNotes}>
                             <div className="input-wrapper">
+
                                 <textarea value={this.state.currentNote} onChange={this.getEditNotes}/>
+
                             </div>
                             <div className="save-button-wrapper">
                                 <input

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -15,8 +15,6 @@ class DescriptionContent extends Component {
             isEditingFoodItems: false,
             isEditingNotes: false,
             currentNote: this.props.delivery.notes,
-
-
             // 'waiting' is true after 'Saved' is clicked and before changes
             // from db is propagated down. While it is true, input fields are
             // disabled
@@ -207,7 +205,6 @@ class DescriptionContent extends Component {
                             {' '}Last edited by {lastEdited.name},{' '}{lastEdited.time}
                         </p>
                     }
-
 
                     {!this.state.isEditingFoodItems ? (
                         <div>

--- a/src/PageContent/Calendar/DescriptionContent.js
+++ b/src/PageContent/Calendar/DescriptionContent.js
@@ -14,6 +14,8 @@ class DescriptionContent extends Component {
         this.state = {
             isEditingFoodItems: false,
             isEditingNotes: false,
+            currentNote: null,
+
             // 'waiting' is true after 'Saved' is clicked and before changes
             // from db is propagated down. While it is true, input fields are
             // disabled
@@ -21,7 +23,7 @@ class DescriptionContent extends Component {
             savedTimestamp: null,
             foodRows: null, // for rendering editable rows only
         };
-
+        this.getEditNotes = this.getEditNotes.bind(this);
         this.editNotes = this.editNotes.bind(this);
         this.editFoodItems = this.editFoodItems.bind(this);
         this.saveFoodItems = this.saveFoodItems.bind(this);
@@ -35,11 +37,12 @@ class DescriptionContent extends Component {
             this.setState({ waiting: false, isEditingFoodItems: false, foodRows: null });
         }
     }
-
+    
     editNotes() {
         {/*const notes = this.props.delivery.notes;*/}
         this.setState({
             isEditingNotes: true,
+            currentNote: this.props.delivery.notes,
         });
     }
 
@@ -68,6 +71,11 @@ class DescriptionContent extends Component {
             foodRows.push({ food: '', quantity: 0, unit: '' });
             return { foodRows: foodRows };
         });
+    }
+
+    getEditNotes(e) {
+        this.setState({currentNote: e.target.value});
+
     }
 
     getEditDonation() {
@@ -101,6 +109,7 @@ class DescriptionContent extends Component {
             );
         });
     }
+
 
     saveFoodItems(e) {
         e.preventDefault();
@@ -265,16 +274,18 @@ class DescriptionContent extends Component {
                 ) : (
                     <div className="content-details-wrapper">
                         <form className="edit-dg" onSubmit={this.saveNotes}>
-                            <textarea value={delivery.notes}/>
-                            
+                            <div className="input-wrapper">
+                                <textarea value={this.state.currentNote} onChange={this.getEditNotes}/>
+                            </div>
                             <div className="save-button-wrapper">
                                 <input
                                     type="submit"
                                     className="description-edit-button"
                                     value={this.state.waiting ? 'saving...' : 'save'}
                                 />
-                            </div> 
+                            </div>
                         </form>
+
                     </div>
                 )} 
             </div>

--- a/src/PageContent/Calendar/DonatingAgencyContent.js
+++ b/src/PageContent/Calendar/DonatingAgencyContent.js
@@ -18,7 +18,7 @@ class DonatingAgencyContent extends Component {
                             {daContact.name} ({daContact.phone})
                         </p>
                     </div>
-                </div>
+                </div> 
             </div>
         );
     }

--- a/src/PageContent/Calendar/DonatingAgencyContent.js
+++ b/src/PageContent/Calendar/DonatingAgencyContent.js
@@ -7,7 +7,7 @@ class DonatingAgencyContent extends Component {
         const { donatingAgency, daContact } = this.props.delivery;
         return (
             <div className="wrapper">
-                <img className="content-icon" src={vitamins} alt="volunteer" />
+                <img className="content-icon" src={vitamins} alt="volunteer"/>
                 <div className="content-wrapper">
                     <h1 className="section-header">Dining Hall</h1>
                     <h2 className="organization">
@@ -18,7 +18,7 @@ class DonatingAgencyContent extends Component {
                             {daContact.name} ({daContact.phone})
                         </p>
                     </div>
-                </div> 
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
Made past events in calendar editable for Delivery Agencies, so that food items/notes can be changed after the date of the pickup has past.
<b>Changes:</b><br>

- removed futureEvent check for isNotesEditable and isFoodEditable boolean fields in DescriptionContent.js <br>

<b>Tests:</b><br>

- Clicked into past event calendar events to check for ability to edit
