### PR TITLE
Editable Receiving Agency Time Availibility

### DIFF
--- a/src/Enums.js
+++ b/src/Enums.js
@@ -169,6 +169,7 @@ exports.SettingsFields = {
         'deliveryNotes', 
         'acceptEmergencyPickups', 
         'uid',
+        'availabilities'
     ],
     MANAGER: [
         'primaryContact', 

--- a/src/PageContent/Settings/OrganizationDetails.js
+++ b/src/PageContent/Settings/OrganizationDetails.js
@@ -2,15 +2,67 @@ import React, { Component } from 'react';
 import Map from '../../Map/Map.js';
 import { AccountType } from '../../Enums';
 import { accountsRef, donatingAgenciesRef } from '../../FirebaseConfig.js';
+import moment from 'moment-timezone';
 
 class OrganizationDetails extends Component {
 
     constructor(props) {
         super(props);
         this.state = {
-            isEditing: false
+            isEditing: false,
+            times: [],
         };
+        this.convertTimes = this.convertTimes.bind(this);
+        this.dayRow = this.dayRow.bind(this);
+        this.dayNames = ['Sun','Mon','Tue','Wed','Thur','Fri','Sat'];
+
+
     }
+
+    dayRow(i, day) {
+
+        var checkboxName = day + 'Check';
+        var startName = day + 'Start';
+        var endName = day + 'End';
+
+        // populate default values if exists
+        var checked = false;
+        var startTime = '';
+        var endTime = '';
+        var availabilities = this.props.org.availabilities;
+        if (availabilities && availabilities[i]) {
+            checked = true;
+            startTime = availabilities[i].startTimestamp;
+            endTime = availabilities[i].endTimestamp;
+            console.log('startTime:', startTime)
+        }
+
+        return (
+            <div className="row" key={day}> 
+                <input type="checkbox" name={checkboxName} defaultChecked={checked} />
+                <div className="day">{day}</div>
+                {/* TODO: AM/PM UI */}
+                <input type="time" name={startName} defaultValue={moment(startTime).format("HH:mm")} className="ra3-inputBox" />
+                <span className="ra3-spacing">to</span>
+                <input type="time" name={endName} defaultValue={moment(endTime).format("HH:mm")} className="ra3-inputBox" />
+            </div>
+        );
+    }
+
+    convertTimes() {
+        var convert = []
+        var dayNames = ['Sun','Mon','Tue','Wed','Thur','Fri','Sat'];
+        for (var i = 0; i < this.props.org.availabilities.length; i++) {
+             if (this.props.org.availabilities[i]) {
+                convert.push(<li>{dayNames[i] + ' ' + moment(this.props.org.availabilities[i].startTimestamp).format("h:mm a") + '-' + moment(this.props.org.availabilities[i].endTimestamp).format("h:mm a")}</li>)
+            }
+            
+        }
+
+        return convert;
+    }
+
+    
 
     render() {
         return (
@@ -43,6 +95,12 @@ class OrganizationDetails extends Component {
                         {this.props.org.deliveryNotes ? <h6>Delivery Notes: {this.props.org.deliveryNotes}</h6> : <span />}
                         {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
                             <h6>Emergency Pickup Activated: {this.props.org.acceptEmergencyPickups ? 'Yes' : 'No'}</h6> 
+                            : 
+                            <span />
+                        }
+                        {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
+                            <h6>Availabilities: {this.convertTimes()}</h6> 
+                            
                             : 
                             <span />
                         }
@@ -83,8 +141,14 @@ class OrganizationDetails extends Component {
                                         :
                                         <span />
                                     }
+
                                     {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
                                         <label className="label-component details">Emergency Pickup</label>
+                                        :
+                                        <span />
+                                    }
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
+                                        <label className="label-component details">Availability</label>
                                         :
                                         <span />
                                     }
@@ -111,7 +175,18 @@ class OrganizationDetails extends Component {
                                         <span />
                                     }
                                     {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
-                                        <input type="checkbox" name="ep" defaultChecked={this.props.org.acceptEmergencyPickups}/>
+                                        <div>
+                                            <input type="checkbox" name="ep" defaultChecked={this.props.org.acceptEmergencyPickups}/><br /><br />
+                                        </div>
+                                        :
+                                        <span />
+                                    }
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ?  
+                                        <div>        
+                                        {this.dayNames.map((day, i) => {
+                                            return this.dayRow(i, day);
+                                        })}
+                                        </div>
                                         :
                                         <span />
                                     }
@@ -148,10 +223,30 @@ class OrganizationDetails extends Component {
             zipcode: e.target.zip.value,
             officeNo: e.target.officeNo.value
         };
+        var availabilities = {};
+        for (let i in this.dayNames) {
+            var day = this.dayNames[i];
+            var checkboxName = day + 'Check';
+
+            // only add availability if checkbox was checked
+            if (e.target[checkboxName].checked ) {
+                var startStr = e.target[day + 'Start'].value; // eg "10:00"
+                var endStr = e.target[day + 'End'].value; // eg "17:00"
+                var dayTimeFormat = 'e HH:mm';  // eg "3 10:00" for Wed 10AM
+                var startTimestamp = moment(i + ' ' + startStr, dayTimeFormat);
+                var endTimestamp = moment(i + ' ' + endStr, dayTimeFormat);
+
+                availabilities[i] = {
+                    startTimestamp: startTimestamp.valueOf(),
+                    endTimestamp: endTimestamp.valueOf()
+                };
+            }
+        }
 
         let updates = {
             address: address,
             name: name,
+            availabilities: availabilities 
         };
 
         if (e.target.num_vol)

--- a/src/PageContent/Settings/OrganizationDetails.js
+++ b/src/PageContent/Settings/OrganizationDetails.js
@@ -15,15 +15,13 @@ class OrganizationDetails extends Component {
         this.convertTimes = this.convertTimes.bind(this);
         this.dayRow = this.dayRow.bind(this);
         this.dayNames = ['Sun','Mon','Tue','Wed','Thur','Fri','Sat'];
-
-
     }
 
     dayRow(i, day) {
 
-        var checkboxName = day + 'Check';
-        var startName = day + 'Start';
-        var endName = day + 'End';
+        let checkboxName = day + 'Check';
+        let startName = day + 'Start';
+        let endName = day + 'End';
 
         // populate default values if exists
         var checked = false;
@@ -34,14 +32,12 @@ class OrganizationDetails extends Component {
             checked = true;
             startTime = availabilities[i].startTimestamp;
             endTime = availabilities[i].endTimestamp;
-            console.log('startTime:', startTime)
         }
 
         return (
             <div className="row" key={day}> 
                 <input type="checkbox" name={checkboxName} defaultChecked={checked} />
                 <div className="day">{day}</div>
-                {/* TODO: AM/PM UI */}
                 <input type="time" name={startName} defaultValue={moment(startTime).format("HH:mm")} className="ra3-inputBox" />
                 <span className="ra3-spacing">to</span>
                 <input type="time" name={endName} defaultValue={moment(endTime).format("HH:mm")} className="ra3-inputBox" />
@@ -54,9 +50,8 @@ class OrganizationDetails extends Component {
         var dayNames = ['Sun','Mon','Tue','Wed','Thur','Fri','Sat'];
         for (var i = 0; i < this.props.org.availabilities.length; i++) {
              if (this.props.org.availabilities[i]) {
-                convert.push(<li>{dayNames[i] + ' ' + moment(this.props.org.availabilities[i].startTimestamp).format("h:mm a") + '-' + moment(this.props.org.availabilities[i].endTimestamp).format("h:mm a")}</li>)
-            }
-            
+                convert.push(<li key={i}>{dayNames[i] + ' ' + moment(this.props.org.availabilities[i].startTimestamp).format("h:mm a") + '-' + moment(this.props.org.availabilities[i].endTimestamp).format("h:mm a")}</li>)
+            }   
         }
 
         return convert;
@@ -129,28 +124,20 @@ class OrganizationDetails extends Component {
                                     <label className="label-component details">State</label><br /><br />
                                     <label className="label-component details">Zip</label><br /><br />
                                     <label className="label-component details">Office Number</label><br /><br />
-                                    {this.props.accountType === AccountType.DELIVERER_GROUP ?  
+                                    {this.props.accountType === AccountType.DELIVERER_GROUP &&  
                                         <label className="label-component details">Volunteers</label>
-                                        :
-                                        <span />
                                     }
-                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY &&
                                         <div>
                                             <label className="label-component details">Delivery Notes</label><br /><br />
                                         </div>
-                                        :
-                                        <span />
                                     }
 
-                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY &&
                                         <label className="label-component details">Emergency Pickup</label>
-                                        :
-                                        <span />
                                     }
-                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY &&
                                         <label className="label-component details">Availability</label>
-                                        :
-                                        <span />
                                     }
                                 </div>
                                 
@@ -162,33 +149,25 @@ class OrganizationDetails extends Component {
                                     <input name="state" type="text" className="form-input" defaultValue={this.props.org.address.state} /><br /><br />
                                     <input name="zip" type="text" className="form-input" defaultValue={this.props.org.address.zipcode} /><br /><br />
                                     <input name="officeNo" type='text' className="form-input" defaultValue={this.props.org.address.officeNo} /><br /><br />
-                                    {this.props.accountType === AccountType.DELIVERER_GROUP ? 
+                                    {this.props.accountType === AccountType.DELIVERER_GROUP && 
                                         <input name="num_vol" type="number" className="form-input" defaultValue={this.props.org.numVolunteers} />
-                                        :
-                                        <span />
                                     }
-                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ?  
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY &&  
                                         <div>
                                             <input name="notes" type="text" className="form-input" defaultValue={this.props.org.deliveryNotes} /><br /><br />
                                         </div>
-                                        :
-                                        <span />
                                     }
-                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ? 
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY && 
                                         <div>
                                             <input type="checkbox" name="ep" defaultChecked={this.props.org.acceptEmergencyPickups}/><br /><br />
                                         </div>
-                                        :
-                                        <span />
                                     }
-                                    {this.props.accountType === AccountType.RECEIVING_AGENCY ?  
+                                    {this.props.accountType === AccountType.RECEIVING_AGENCY &&  
                                         <div>        
                                         {this.dayNames.map((day, i) => {
                                             return this.dayRow(i, day);
                                         })}
                                         </div>
-                                        :
-                                        <span />
                                     }
                                 </div>
                             </div>

--- a/src/PageContent/Settings/Settings.js
+++ b/src/PageContent/Settings/Settings.js
@@ -6,7 +6,6 @@ import MemberAccount from './MemberAccount';
 import PersonalAccount from './PersonalAccount';
 import './SCSettings0.css';
 import './SCSettings1.css';
-import moment from 'moment-timezone';
 
 import { accountsRef, donatingAgenciesRef } from '../../FirebaseConfig.js';
 import { pick } from 'lodash';

--- a/src/PageContent/Settings/Settings.js
+++ b/src/PageContent/Settings/Settings.js
@@ -56,26 +56,7 @@ class Settings extends Component {
                 manager: pick(account, SettingsFields.MANAGER),
             });
         }
-        // if (account.accountType === AccountType.RECEIVING_AGENCY) {
-        //      this.convertTimes(account);
-        // }
     }
-
-    // convertTimes(account) {
-    //     var convert = []
-    //     console.log(this.account.org + 'ORG');
-    //     var dayNames = ['Sun','Mon','Tue','Wed','Thur','Fri','Sat'];
-    //     for (var i = 0; i < this.org.availabilities.length; i++) {
-    //         if (this.state.org.availabilities[i]) {
-    //             convert.push(dayNames[i].toString() + ' ' + moment(this.state.org.availabilities[i].startTimestamp).format("h:mm a").toString()
-    //              + '-' + moment(this.state.org.availabilities[i].endTimestamp).format("h:mm a").toString());
-    //         }    
-    //     } 
-        
-        // this.setState({account.availabilities: convert});
-     //   console.log(convert)
-     //   console.log(this.org.availabilities)
-   // }
 
     async getDaInfo(account) {
         // get da org info

--- a/src/PageContent/Settings/Settings.js
+++ b/src/PageContent/Settings/Settings.js
@@ -32,6 +32,7 @@ class Settings extends Component {
             });
         }
     }
+    
     componentWillReceiveProps(nextProps) {
         if (this.props.account !== nextProps.account) {
             // remove listener
@@ -110,7 +111,7 @@ class Settings extends Component {
                                 <div>Loading...</div>  
                             }
                         </div>
-                        <div> {this.props.availabilities}</div>
+                        {/* <div> {this.props.availabilities}</div> */}
                         <div className="scs-spacing" />
 
                         <div className="container">

--- a/src/PageContent/Settings/Settings.js
+++ b/src/PageContent/Settings/Settings.js
@@ -6,6 +6,7 @@ import MemberAccount from './MemberAccount';
 import PersonalAccount from './PersonalAccount';
 import './SCSettings0.css';
 import './SCSettings1.css';
+import moment from 'moment-timezone';
 
 import { accountsRef, donatingAgenciesRef } from '../../FirebaseConfig.js';
 import { pick } from 'lodash';
@@ -32,7 +33,6 @@ class Settings extends Component {
             });
         }
     }
-
     componentWillReceiveProps(nextProps) {
         if (this.props.account !== nextProps.account) {
             // remove listener
@@ -56,7 +56,26 @@ class Settings extends Component {
                 manager: pick(account, SettingsFields.MANAGER),
             });
         }
+        // if (account.accountType === AccountType.RECEIVING_AGENCY) {
+        //      this.convertTimes(account);
+        // }
     }
+
+    // convertTimes(account) {
+    //     var convert = []
+    //     console.log(this.account.org + 'ORG');
+    //     var dayNames = ['Sun','Mon','Tue','Wed','Thur','Fri','Sat'];
+    //     for (var i = 0; i < this.org.availabilities.length; i++) {
+    //         if (this.state.org.availabilities[i]) {
+    //             convert.push(dayNames[i].toString() + ' ' + moment(this.state.org.availabilities[i].startTimestamp).format("h:mm a").toString()
+    //              + '-' + moment(this.state.org.availabilities[i].endTimestamp).format("h:mm a").toString());
+    //         }    
+    //     } 
+        
+        // this.setState({account.availabilities: convert});
+     //   console.log(convert)
+     //   console.log(this.org.availabilities)
+   // }
 
     async getDaInfo(account) {
         // get da org info
@@ -111,7 +130,7 @@ class Settings extends Component {
                                 <div>Loading...</div>  
                             }
                         </div>
-
+                        <div> {this.props.availabilities}</div>
                         <div className="scs-spacing" />
 
                         <div className="container">


### PR DESCRIPTION
In the receiving agency settings page where organization details are made visible, the agency's availability times are now displayed and can be edited. 
<b>Changes: </b><br>

- `src/Enums.js`, added availability to SettingsFields so that is is accessible. 

- `src/PageContent/Settings/OrganizationDetails.js` display availability times and have option to edit them.
<br>
<b> Tests: </b><br>

- Edited times for receiving agency and made sure that it was displayed correctly on settings page.

- checked that nothing weird was going on with settings page of DA or DG.