### PR TITLE
Hotfix recurring pickup limit

### DIFF
--- a/src/PageContent/RequestPickup/PickupSummary.js
+++ b/src/PageContent/RequestPickup/PickupSummary.js
@@ -27,7 +27,7 @@ class PickupSummary extends React.Component {
             this.props.request.endCriteria.type === RequestEndCriteriaType.OCCUR
         ) {
             durationText =
-                this.props.request.endCriteria.value + ' pickups requested';
+                this.props.request.endCriteria.value + ' pickup(s) requested';
         } else {
             durationText =
                 'Ending ' +

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -28,7 +28,9 @@ class RecurringPickupRequest extends Component {
             primaryContact: {},
             raRequested: null,
             dgRequested: null,
-            submissionError: null
+            submissionError: null,
+            // required: true,
+            // star: "*"
         };
 
         this.formId = 'recurringRequestForm';
@@ -157,6 +159,8 @@ class RecurringPickupRequest extends Component {
         this.setState(prevState => {
             let fields = prevState.fields;
             fields[field] = val;
+            // star = (fields['occurTimes'] > 1) ? "*" : "";
+            // required = (fields['ocucurTimes'] > 1)
             return { fields: fields };
         });
     }
@@ -394,7 +398,9 @@ class RecurringPickupRequest extends Component {
                         <span className="flex">
                             <span className="grid">
                                 <label>
-                                    Repeats <span className="red">*</span>
+                                    Repeats <span className="red">
+                                    {(this.state.fields['endCriteria'] === RequestEndCriteriaType.OCCUR &&
+                                        this.state.fields['occurTimes'] == 1 ? "" : "*")}</span>
                                 </label>
                                 <br />
                                 <select name="repeats" defaultValue="" required>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -134,7 +134,7 @@ class RecurringPickupRequest extends Component {
         } else if (
             fields['occurTimes'] === '' ||
             !fields['occurTimes'] ||
-            fields['occurTimes'] < 2
+            fields['occurTimes'] < 1
         ) {
             formIsValid = false;
             errors['invalidOccurTimes'] = 'Pickup must recur at least once';

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -403,7 +403,7 @@ class RecurringPickupRequest extends Component {
                                         this.state.fields['occurTimes'] === '1' ? "" : "*")}</span>
                                 </label>
                                 <br />
-                                <select name="repeats" defaultValue="" required>
+                                <select name="repeats" defaultValue="" required={this.state.fields['occurTimes'] !== '1'}>
                                     <option value="" disabled>
                                         Select
                                     </option>

--- a/src/PageContent/RequestPickup/RecurringPickupRequest.js
+++ b/src/PageContent/RequestPickup/RecurringPickupRequest.js
@@ -400,7 +400,7 @@ class RecurringPickupRequest extends Component {
                                 <label>
                                     Repeats <span className="red">
                                     {(this.state.fields['endCriteria'] === RequestEndCriteriaType.OCCUR &&
-                                        this.state.fields['occurTimes'] == 1 ? "" : "*")}</span>
+                                        this.state.fields['occurTimes'] === '1' ? "" : "*")}</span>
                                 </label>
                                 <br />
                                 <select name="repeats" defaultValue="" required>

--- a/src/PageLayout/Notification/Details/RequestTime.js
+++ b/src/PageLayout/Notification/Details/RequestTime.js
@@ -24,7 +24,7 @@ class RequestTime extends React.Component {
             this.props.request.endCriteria.type === RequestEndCriteriaType.OCCUR
         ) {
             durationText =
-                this.props.request.endCriteria.value + ' pickups requested';
+                this.props.request.endCriteria.value + ' pickup(s) requested';
         } else {
             durationText =
                 'Ending ' +


### PR DESCRIPTION
Made limit for recurring pickup 1 delivery instead of 2.

**Changes**

- `src/PageContent/RequestPickup/RecurringPickupRequest.js`: changed occurLimit minimum to be 1 not 2. (line 137)
- `src/PageContent/RequestPickup/PickupSummary.js` and `src/PageLayout/Notification/Details/RequestTime.js` to match new occurrence limit, changed "pickups requested" to pickup(s) requested (line 30 and 27 respectively)

**Testing**

- Went through the scheduling process (all 3 confirmations) and double checked that delivery looked good in firebase.