### PR TITLE
updated failed sign in message

### DIFF
--- a/src/SignUpIn/SignIn.js
+++ b/src/SignUpIn/SignIn.js
@@ -134,7 +134,7 @@ class SignIn extends Component {
                             {this.state.error && (
                                 /* TODO: give better error msg */
                                 <p className="sign-in-error">
-                                    Unable to log in.
+                                    Unable to log in. Incorrect email or password entered.
                                 </p>
                             )}
                             <div className="login-button-wrapper">


### PR DESCRIPTION
**Changes**

- `src/SignUpIn/SignIn.js` - updated "unable to log in" message to say the username or password is wrong. This is different than if the account exists but isn't authenticated or validated.